### PR TITLE
Add line to switch to root account

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -11,6 +11,8 @@
     date: "{{ lookup('pipe', 'date -u +%Y%m%d-%H%M%S') }}"
     home: "/home/{{ poa_role }}"
   user: root
+  become: true
+  become_user: root
   roles:
     - hf-spec-change
   tags: hf-spec


### PR DESCRIPTION
Explicitly set to become `root` for the case when connecting as another user.