### PR TITLE
Set default branch name to CORE in hf-spec-change

### DIFF
--- a/group_vars/hf-spec-change.example
+++ b/group_vars/hf-spec-change.example
@@ -4,4 +4,4 @@ poa_role: "bootnode"
 
 # repo to fetch HFs from
 MAIN_REPO_FETCH: "poanetwork"
-GENESIS_BRANCH: "sokol"
+GENESIS_BRANCH: "core"


### PR DESCRIPTION
DO NOT MERGE YET, until HF date on core is announced.

In preparation for HF on Core, update default branch name to for spec updates to `core`
