### PR TITLE
Update Parity version to v2.6.8

### DIFF
--- a/roles/upd-parity-version/tasks/main.yml
+++ b/roles/upd-parity-version/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - set_fact:
-    PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.2/x86_64-unknown-linux-gnu/parity"
-    PARITY_BIN_SHA256: "593c2f622fbb04a4baccd3388b66d2d1b1a5bd207201335ab5b26a3ed95d182f"
-    PARITY_VERSION_CHECK: "2.6.2"
+    PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.8/x86_64-unknown-linux-gnu/parity"
+    PARITY_BIN_SHA256: "299f928503cb3b8d44d95a0f592e32358542ec854842c277e3eeaee2a3478a28"
+    PARITY_VERSION_CHECK: "2.6.8"
   when: GENESIS_BRANCH == 'sokol'
 
 - set_fact:
@@ -12,15 +12,15 @@
   when: GENESIS_BRANCH == 'kovan'
 
 - set_fact:
-    PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.2/x86_64-unknown-linux-gnu/parity"
-    PARITY_BIN_SHA256: "593c2f622fbb04a4baccd3388b66d2d1b1a5bd207201335ab5b26a3ed95d182f"
-    PARITY_VERSION_CHECK: "2.6.2"
+    PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.8/x86_64-unknown-linux-gnu/parity"
+    PARITY_BIN_SHA256: "299f928503cb3b8d44d95a0f592e32358542ec854842c277e3eeaee2a3478a28"
+    PARITY_VERSION_CHECK: "2.6.8"
   when: GENESIS_BRANCH == 'dai'
 
 - set_fact:
-    PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.2/x86_64-unknown-linux-gnu/parity"
-    PARITY_BIN_SHA256: "593c2f622fbb04a4baccd3388b66d2d1b1a5bd207201335ab5b26a3ed95d182f"
-    PARITY_VERSION_CHECK: "2.6.2"
+    PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.8/x86_64-unknown-linux-gnu/parity"
+    PARITY_BIN_SHA256: "299f928503cb3b8d44d95a0f592e32358542ec854842c277e3eeaee2a3478a28"
+    PARITY_VERSION_CHECK: "2.6.8"
   when: GENESIS_BRANCH == 'core'
 
 - set_fact:


### PR DESCRIPTION
This PR updates an URL to Parity binary and its SHA256 hash along with its version string. These changes are for `POA Core`, `POA Sokol`, and `xDai` chains and can be used with the instruction https://www.poa.network/for-validators/hard-forks/parity-upgrade-guide

For `Kovan` the version left unchanged because upgrading to `v2.6.8` on `Kovan` assumes that `spec.json` format should also be changed (for this [the separate instruction](https://forum.poa.network/t/criticial-security-urgent-parity-update-to-v2-6-8-or-later/3215) is available). I propose to update the version for `Kovan` in a separate PR after `Kovan` validators upgrade their nodes to `v2.6.8` using that instruction on the forum.